### PR TITLE
Fix listRefs

### DIFF
--- a/Data/Git/Named.hs
+++ b/Data/Git/Named.hs
@@ -142,7 +142,7 @@ listRefs root = listRefsAcc [] root
         getRefsRecursively dir acc (x:xs) = do
             isDir <- isDirectory x
             extra <- if isDir
-                        then listRefsAcc [] dir
+                        then listRefsAcc [] x
                         else let r = UTF8.toString $ localPathEncode $ stripRoot x
                               in if isValidRefName r
                                     then return [fromString r]


### PR DESCRIPTION
Would loop indefinitely when passed a `LocalPath` containing forward slashes.