### PR TITLE
Data.Git.Monad.hs: port to MonadFail proposal

### DIFF
--- a/Data/Git/Monad.hs
+++ b/Data/Git/Monad.hs
@@ -17,7 +17,7 @@
 --
 -- You can also easily create a new commit: see 'CommitM' and 'withNewCommit'
 --
-
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Rank2Types #-}
@@ -74,7 +74,9 @@ module Data.Git.Monad
     , Git.Person(..)
     ) where
 
-
+#if !MIN_VERSION_base(4,11,0)
+import qualified Control.Monad.Fail as Fail
+#endif
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as BL
@@ -240,7 +242,11 @@ instance Applicative GitM where
 instance Monad GitM where
     return = returnGitM
     (>>=)  = bindGitM
-    fail   = failGitM
+#if !MIN_VERSION_base(4,11,0)
+    fail   = Fail.fail
+#endif
+instance MonadFail GitM where
+    fail = failGitM
 
 instance GitMonad GitM where
     getGit  = getGitM
@@ -313,7 +319,11 @@ instance Applicative CommitAccessM where
 instance Monad CommitAccessM where
     return = returnCommitAccessM
     (>>=)  = bindCommitAccessM
-    fail   = failCommitAccessM
+#if !MIN_VERSION_base(4,11,0)
+    fail   = Fail.fail
+#endif
+instance MonadFail CommitAccessM where
+    fail = failCommitAccessM
 
 instance GitMonad CommitAccessM where
     getGit  = getCommitAccessM
@@ -423,7 +433,7 @@ getDir fp = do
 -- >        l <- getDir []
 -- >        liftGit $ print l
 --
-withCommit :: (Resolvable ref, GitMonad git)
+withCommit :: (Resolvable ref, GitMonad git, MonadFail git)
            => ref
                 -- ^ the commit revision or reference to open
            -> CommitAccessM a
@@ -474,7 +484,11 @@ instance Applicative CommitM where
 instance Monad CommitM where
     return = returnCommitM
     (>>=)  = bindCommitM
-    fail   = failCommitM
+#if !MIN_VERSION_base(4,11,0)
+    fail   = Fail.fail
+#endif
+instance MonadFail CommitM where
+    fail = failCommitM
 
 instance GitMonad CommitM where
     getGit  = getCommitM
@@ -599,7 +613,7 @@ deleteFile path = do
 -- >        setFile ["README.md"] $ readmeContent <> "just add some more description\n"
 -- >    branchWrite "master" r
 --
-withNewCommit :: (GitMonad git, Resolvable rev)
+withNewCommit :: (GitMonad git, MonadFail git, Resolvable rev)
               => Git.Person
                 -- ^ by default a commit must have an Author and a Committer.
                 --
@@ -670,7 +684,7 @@ withNewCommit p mPrec m = do
 --         )
 -- @
 --
-withBranch :: GitMonad git
+withBranch :: (GitMonad git, MonadFail git)
            => Git.Person
                 -- ^ the default Author and Committer (see 'withNewCommit')
            -> Git.RefName


### PR DESCRIPTION
This is a patch from the Gentoo Haskell project to make `hs-git` build with `ghc-8.8.3` (written by me, so no copyright issues here). See https://github.com/gentoo-haskell/gentoo-haskell/commit/d9d35ad721fdb04aba9cbc019749cead12a83e91

Note that I have *only* tested this on ghc-8.8.3. The CPP conditional code check for `<base-4.11` has not been tested. I've simply implemented the example at https://wiki.haskell.org/MonadFail_Proposal. While I understand that this is less than ideal, I think it's better that I upstream a patch that at least works for our use case at Gentoo Haskell, as a base to build off.

As it stands, this patch builds and all tests succeed.