### PR TITLE
Remove deprecated packages

### DIFF
--- a/Data/Git/Index.hs
+++ b/Data/Git/Index.hs
@@ -9,9 +9,6 @@ module Data.Git.Index
     , indexEntryOfFile
     ) where
 
-import Prelude hiding ( FilePath, readFile )
-import Filesystem
-import Filesystem.Path hiding (concat)
 import Control.Monad( when
                     , replicateM
                     )
@@ -57,7 +54,7 @@ indexEntryOfFile :: HashAlgorithm hash => B.ByteString -> V.Vector (IndexEntry h
 indexEntryOfFile path vec = binarySearchBy (compare . fileName) vec path
 
 loadIndexFile :: HashAlgorithm hash => FilePath -> IO (Either String (V.Vector (IndexEntry hash)))
-loadIndexFile path = (decodeIndex <$> readFile path) `E.catch` onError
+loadIndexFile path = (decodeIndex <$> BC.readFile path) `E.catch` onError
   where
     onError :: E.SomeException -> IO (Either String a)
     onError _ = return $ Left "Cannot find index file"

--- a/Data/Git/Named.hs
+++ b/Data/Git/Named.hs
@@ -114,7 +114,7 @@ readPackedRefs :: HashAlgorithm hash
                -> ([(RefName, Ref hash)] -> a)
                -> IO (PackedRefs a)
 readPackedRefs gitRepo constr = do
-    exists <- isFile (packedRefsPath gitRepo)
+    exists <- doesFileExist (packedRefsPath gitRepo)
     if exists then readLines else return $ finalize emptyPackedRefs
   where emptyPackedRefs = PackedRefs [] [] []
         readLines = finalize . foldl accu emptyPackedRefs . BC.lines <$> readBinaryFile (packedRefsPath gitRepo)
@@ -140,10 +140,10 @@ listRefs root = listRefsAcc [] root
             getRefsRecursively dir acc files
         getRefsRecursively _   acc []     = return acc
         getRefsRecursively dir acc (x:xs) = do
-            isDir <- isDirectory x
+            isDir <- doesDirectoryExist x
             extra <- if isDir
                         then listRefsAcc [] x
-                        else let r = UTF8.toString $ localPathEncode $ stripRoot x
+                        else let r = stripRoot x
                               in if isValidRefName r
                                     then return [fromString r]
                                     else return []
@@ -160,7 +160,7 @@ looseRemotesList :: LocalPath -> IO [RefName]
 looseRemotesList gitRepo = listRefs (remotesPath gitRepo)
 
 existsRefFile :: LocalPath -> RefSpecTy -> IO Bool
-existsRefFile gitRepo specty = isFile $ toPath gitRepo specty
+existsRefFile gitRepo specty = doesFileExist $ toPath gitRepo specty
 
 writeRefFile :: LocalPath -> RefSpecTy -> RefContentTy hash -> IO ()
 writeRefFile gitRepo specty refcont = do

--- a/Data/Git/Storage/Object.hs
+++ b/Data/Git/Storage/Object.hs
@@ -55,7 +55,7 @@ import Data.Word
 import Text.Printf
 
 #if MIN_VERSION_bytestring(0,10,0)
-import Data.ByteString.Lazy.Builder hiding (word8)
+import Data.ByteString.Builder hiding (word8)
 #else
 import qualified Data.ByteString.Lazy.Char8 as LC
 

--- a/git.cabal
+++ b/git.cabal
@@ -39,9 +39,9 @@ Library
                    , hourglass >= 0.2
                    , unix-compat
                    , utf8-string
-                   -- to remove
-                   , system-filepath
-                   , system-fileio
+                   , directory >= 1.2.5.0
+                   , filepath
+                   , unix
   Exposed-modules:   Data.Git
                      Data.Git.Monad
                      Data.Git.Types


### PR DESCRIPTION
`system-filepath` and `system-fileio` have been deprecated. This removes them and replaces their functions with newer alternatives.